### PR TITLE
fix pytorch 1.4 compatibility

### DIFF
--- a/mictorch/nms/nms_cpu.cpp
+++ b/mictorch/nms/nms_cpu.cpp
@@ -111,7 +111,7 @@ at::Tensor nms(
     return nms_cpu_forward(bbs, conf, nms_threshold, max_output_boxes);
 }
 
-static auto registry = torch::jit::RegisterOperators()
+static auto registry = torch::RegisterOperators()
   .op("mtorch_ops::nms(Tensor bbs, Tensor conf,"
       "float nms_threshold, int max_output_boxes) -> Tensor",
       &nms);

--- a/mictorch/nmsfilt/nmsfilt_cpu.cpp
+++ b/mictorch/nmsfilt/nmsfilt_cpu.cpp
@@ -141,7 +141,7 @@ at::Tensor nmsfilt(
     return nmsfilt_forward(bbs, conf, nms_threshold, 1, pre_threshold, 0, max_output_boxes)[0];
 }
 
-static auto registry = torch::jit::RegisterOperators()
+static auto registry = torch::RegisterOperators()
   .op("mtorch_ops::nmsfilt(Tensor bbs, Tensor conf,"
       "float nms_threshold, float pre_threshold, int max_output_boxes) -> Tensor",
       &nmsfilt);


### PR DESCRIPTION
`torch::jit::RegisterOperators` is removed from Pytorch version 1.4 and replaced with `torch::RegisterOperators`.
Although this PR breaks compatibility with Pytorch 1.1 and lower